### PR TITLE
Adds ability to receive keystore password from STDIN

### DIFF
--- a/add_mozilla_ca_certs_to_java_keystore.py
+++ b/add_mozilla_ca_certs_to_java_keystore.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 
 import requests
+import sys
 
 __version__ = "1.0.0"
 
@@ -72,7 +73,10 @@ def main(args):
         os.chdir(args.working_dir)
         cert_dir = os.path.join(args.working_dir, cert_dir)
     check_requirements()
-    store_passwd = getpass.getpass('Enter the keystore password:')
+    if sys.stdin.isatty():
+        store_passwd = getpass.getpass('Enter the keystore password:')
+    else:
+        store_passwd = sys.stdin.readline().rstrip()
     download_url_to_file(go_extract_script_url,
                          'convert_mozilla_certdata.go')
     download_url_to_file(args.mozilla_cert_url, 'certdata.txt')


### PR DESCRIPTION
This way you can use the add_mozilla_ca_certs_to_java_keystore.py in a shell script
and pipe the password like this:
```
echo "XXXXXX" | python add_mozilla_ca_certs_to_java_keystore.py ......
```